### PR TITLE
Change the secrets manager portion to get only the app cert secret na…

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -44,11 +44,14 @@ on configuration options, open the configuration documentation:
 >> https://www.ory.sh/oathkeeper/docs/configuration <<
 `,
 	Run: func(cmd *cobra.Command, args []string) {
-		if err := x.LoadSecretsToEnv(); err != nil {
+		data, err := x.GetMainSecrets()
+		if err != nil {
 			log.Fatal(err)
 		}
-		if err := x.SetupAppCerts(); err != nil {
-			log.Fatal(err)
+		if data != nil {
+			if err := x.SetupAppCerts(data[x.AppCertSecretEnvName]); err != nil {
+				log.Fatal(err)
+			}
 		}
 
 		logger = viperx.InitializeConfig("oathkeeper", "", logger)

--- a/x/secrets.go
+++ b/x/secrets.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	appCertSecretEnvName = "AWS_APP_CERTS_SECRET_NAME"
+	AppCertSecretEnvName = "AWS_APP_CERTS_SECRET_NAME"
 	appSSLCert           = "app_ssl_certificate"
 	appSSLKey            = "app_ssl_certificate_key"
 
@@ -22,24 +22,24 @@ const (
 	apiKeyEnvName        = "SERVE_API_TLS_KEY_BASE64"
 )
 
-func LoadSecretsToEnv() error {
+func GetMainSecrets() (map[string]string, error) {
 	smName := os.Getenv(SecretManagerEnvName)
 	if smName == "" {
-		return nil
+		return nil, nil
 	}
 	if os.Getenv(AWSRegionEnvName) == "" {
 		//Default region to us-east-1
 		if err := os.Setenv(AWSRegionEnvName, "us-east-1"); err != nil {
-			return err
+			return nil, err
 		}
 	}
-	return conf.WriteSecretsToENV(smName)
+	data, _, err := conf.GetSecrets(smName)
+	return data, err
 }
 
 //SetupAppCerts gets a cert and a key from secrets manager. It extracts the base64
 //portion in the cert and the key and sets them to the corresponding env variables.
-func SetupAppCerts() error {
-	appcertsSecretName := os.Getenv(appCertSecretEnvName)
+func SetupAppCerts(appcertsSecretName string) error {
 	if appcertsSecretName == "" {
 		return nil
 	}


### PR DESCRIPTION
…me, instead of writing the entire secrets to env variables, because those secrets are for Hydra

The env variables in secrets manager are for Hydra to use, not Oathkeeper. Oathkeeper only needs the name of the app cert secret name. So changed it to retrieve only app cert secret name and use it to get app certs.

- [x] @abdulchaudhrycoupa 