### PR TITLE
Fix how the app certs are passed to oathkeeper's env variables. Turns…

### DIFF
--- a/x/secrets_test.go
+++ b/x/secrets_test.go
@@ -1,17 +1,20 @@
 package x
 
 import (
+	"encoding/base64"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
-func TestExtractCertBase64(t *testing.T) {
+func TestProcessAndEncode(t *testing.T) {
 	cert := "-----BEGIN CERTIFICATE-----\\nLINE1\\nLINE2-----END CERTIFICATE-----\\n"
-	assert.Equal(t, extractCertBase64(cert), "LINE1LINE2")
-}
+	expected := "-----BEGIN CERTIFICATE-----\nLINE1\nLINE2-----END CERTIFICATE-----\n"
 
-func TestExtractKeyBase64(t *testing.T) {
-	cert := "-----BEGIN RSA PRIVATE KEY-----\\nLINE1\\nLINE2-----END RSA PRIVATE KEY-----\\n"
-	assert.Equal(t, extractKeyBase64(cert), "LINE1LINE2")
+	assert.Equal(t, processAndEncode(cert), base64.StdEncoding.EncodeToString([]byte(expected)))
+
+	key := "-----BEGIN RSA PRIVATE KEY-----\\nLINE1\\nLINE2-----END RSA PRIVATE KEY-----\\n"
+	expected = "-----BEGIN RSA PRIVATE KEY-----\nLINE1\nLINE2-----END RSA PRIVATE KEY-----\n"
+
+	assert.Equal(t, processAndEncode(key), base64.StdEncoding.EncodeToString([]byte(expected)))
 }


### PR DESCRIPTION
… out they have to be base64 encoded on the entire pem

Previous I was passing the base64 content in a pem (what's between the starting and ending ---xxx---) to the env variable, that didn't work.

Turned out I need to base64 encode the entire pem and set it to the env variable.

- [x] @abdulchaudhrycoupa 